### PR TITLE
Resolves #2

### DIFF
--- a/include/learned_sort.h
+++ b/include/learned_sort.h
@@ -188,7 +188,7 @@ template <class RandomIt>
 learned_sort::RMI<typename iterator_traits<RandomIt>::value_type>
 learned_sort::train(
     RandomIt begin, RandomIt end,
-    RMI<typename iterator_traits<RandomIt>::value_type>::Params &p) {
+    typename RMI<typename iterator_traits<RandomIt>::value_type>::Params &p) {
   // Determine the data type
   typedef typename iterator_traits<RandomIt>::value_type T;
 
@@ -953,7 +953,7 @@ void _sort_trained(
 template <class RandomIt>
 void learned_sort::sort(
     RandomIt begin, RandomIt end,
-    RMI<typename iterator_traits<RandomIt>::value_type>::Params &params) {
+    typename RMI<typename iterator_traits<RandomIt>::value_type>::Params &params) {
   // Use std::sort for very small arrays
   if (std::distance(begin, end) <=
       std::max(params.fanout * params.threshold, 5 * params.arch[1])) {

--- a/include/learned_sort.h
+++ b/include/learned_sort.h
@@ -93,8 +93,7 @@ class RMI {
   // Member variables of the CDF model
   bool trained;
   vector<vector<linear_model>> models;
-  double *training_sample = nullptr;
-  unsigned int training_sample_sz = 0;
+  vector<double> training_sample;
   Params hp;
 
   // CDF model constructor
@@ -243,22 +242,21 @@ learned_sort::RMI learned_sort::train(RandomIt begin, RandomIt end,
                                        RMI::Params::MIN_SORTING_SIZE));
 
   // Create a sample array
-  rmi.training_sample = new double[SAMPLE_SZ];
+  rmi.training_sample.reserve(SAMPLE_SZ);
 
   // Start sampling
   unsigned int offset = static_cast<unsigned int>(1. * INPUT_SZ / SAMPLE_SZ);
   for (auto i = begin; i < end; i += offset) {
     // NOTE:  We don't directly assign SAMPLE_SZ to rmi.training_sample_sz
     //        to avoid issues with divisibility
-    rmi.training_sample[rmi.training_sample_sz++] = static_cast<double>(*i);
+    rmi.training_sample.push_back(*i);
   }
 
   // Sort the sample using the provided comparison function
-  std::sort(rmi.training_sample, rmi.training_sample + rmi.training_sample_sz);
+  std::sort(rmi.training_sample.begin(), rmi.training_sample.end());
 
   // Stop early if the array is identical
-  if (rmi.training_sample[0] ==
-      rmi.training_sample[rmi.training_sample_sz - 1]) {
+  if (rmi.training_sample.front() == rmi.training_sample.back()) {
     return rmi;
   }
 
@@ -268,11 +266,7 @@ learned_sort::RMI learned_sort::train(RandomIt begin, RandomIt end,
 
   // Populate the training data for the root model
   for (unsigned int i = 0; i < SAMPLE_SZ; ++i) {
-    training_point<T> tp;
-    tp.x = rmi.training_sample[i];
-    tp.y = static_cast<float>(i) / SAMPLE_SZ;
-
-    training_data[0][0].push_back(tp);
+    training_data[0][0].push_back({rmi.training_sample[i], 1. * i / SAMPLE_SZ});
   }
 
   // Train the root model using linear interpolation
@@ -421,7 +415,7 @@ void _sort_trained(RandomIt begin, RandomIt end, learned_sort::RMI &rmi) {
   // Constants for repeated keys
   const unsigned int EXCEPTION_VEC_INIT_CAPACITY = FANOUT;
   constexpr unsigned int EXC_CNT_THRESHOLD = 60;
-  const size_t TRAINING_SAMPLE_SZ = rmi.training_sample_sz;
+  const size_t TRAINING_SAMPLE_SZ = rmi.training_sample.size();
 
   // Initialize the spill bucket
   vector<T> spill_bucket;
@@ -450,10 +444,10 @@ void _sort_trained(RandomIt begin, RandomIt end, learned_sort::RMI &rmi) {
   auto root_slope = rmi.models[0][0].slope;
   auto root_intrcpt = rmi.models[0][0].intercept;
   unsigned int num_models = rmi.hp.arch[1];
-  vector<double> slopes, intercpts;
+  vector<double> slopes, intercepts;
   for (unsigned int i = 0; i < num_models; ++i) {
     slopes.push_back(rmi.models[1][i].slope);
-    intercpts.push_back(rmi.models[1][i].intercept);
+    intercepts.push_back(rmi.models[1][i].intercept);
   }
 
   //----------------------------------------------------------//
@@ -466,7 +460,7 @@ void _sort_trained(RandomIt begin, RandomIt end, learned_sort::RMI &rmi) {
     if (rmi.training_sample[i] == rmi.training_sample[i - 1]) {
       ++cnt_rep_keys;
     } else {  // New values start here. Reset counter. Add value in the
-      // exeception_vals if above threshold
+      // exception_vals if above threshold
       if (cnt_rep_keys > EXC_CNT_THRESHOLD) {
         repeated_keys.push_back(rmi.training_sample[i - 1]);
       }
@@ -477,8 +471,6 @@ void _sort_trained(RandomIt begin, RandomIt end, learned_sort::RMI &rmi) {
   if (cnt_rep_keys > EXC_CNT_THRESHOLD) {  // Last batch of repeated keys
     repeated_keys.push_back(rmi.training_sample[TRAINING_SAMPLE_SZ - 1]);
   }
-
-  delete[] rmi.training_sample;
 
   //----------------------------------------------------------//
   //             SHUFFLE THE KEYS INTO BUCKETS                //
@@ -494,7 +486,7 @@ void _sort_trained(RandomIt begin, RandomIt end, learned_sort::RMI &rmi) {
         std::max(0., std::min(num_models - 1.,
                               root_slope * repeated_keys[i] + root_intrcpt)));
     pred_cdf =
-        slopes[pred_model_idx] * repeated_keys[i] + intercpts[pred_model_idx];
+        slopes[pred_model_idx] * repeated_keys[i] + intercepts[pred_model_idx];
     pred_model_idx = static_cast<int>(
         std::max(0., std::min(FANOUT - 1., pred_cdf * FANOUT)));
 
@@ -515,7 +507,7 @@ void _sort_trained(RandomIt begin, RandomIt end, learned_sort::RMI &rmi) {
 
       // Predict the CDF
       pred_cdf =
-          slopes[pred_model_idx] * cur_key[0] + intercpts[pred_model_idx];
+          slopes[pred_model_idx] * cur_key[0] + intercepts[pred_model_idx];
 
       // Scale the CDF to the number of buckets
       pred_model_idx = static_cast<int>(
@@ -551,7 +543,7 @@ void _sort_trained(RandomIt begin, RandomIt end, learned_sort::RMI &rmi) {
 
         // Predict the CDF
         pred_cdf = slopes[pred_idx_in_batch_exc[elm_idx]] * cur_key[elm_idx] +
-                   intercpts[pred_idx_in_batch_exc[elm_idx]];
+                   intercepts[pred_idx_in_batch_exc[elm_idx]];
 
         // Extrapolate the CDF to the number of buckets
         pred_idx_in_batch_exc[elm_idx] = static_cast<unsigned int>(
@@ -657,7 +649,7 @@ void _sort_trained(RandomIt begin, RandomIt end, learned_sort::RMI &rmi) {
 
         // Predict the CDF
         pred_cdf = slopes[batch_cache[elm_idx]] * cur_elm +
-                   intercpts[batch_cache[elm_idx]];
+                   intercepts[batch_cache[elm_idx]];
 
         // Scale the predicted CDF to the number of minor buckets and cache it
         batch_cache[elm_idx] = static_cast<int>(std::max(
@@ -702,7 +694,7 @@ void _sort_trained(RandomIt begin, RandomIt end, learned_sort::RMI &rmi) {
       batch_cache[elm_idx] = static_cast<int>(std::max(
           0., std::min(num_models - 1., root_slope * cur_elm + root_intrcpt)));
       pred_cdf = slopes[batch_cache[elm_idx]] * cur_elm +
-                 intercpts[batch_cache[elm_idx]];
+                 intercepts[batch_cache[elm_idx]];
       batch_cache[elm_idx] = static_cast<int>(std::max(
           0., std::min(NUM_MINOR_BCKT_PER_MAJOR_BCKT - 1.,
                        pred_cdf * TOT_NUM_MINOR_BCKTS -
@@ -771,7 +763,7 @@ void _sort_trained(RandomIt begin, RandomIt end, learned_sort::RMI &rmi) {
 
             // Predict the CDF
             pred_cdf = slopes[pred_model_first_elm] * cur_elm +
-                       intercpts[pred_model_first_elm];
+                       intercepts[pred_model_first_elm];
 
             // Scale the predicted CDF to the input size and cache it
             pred_idx_cache[elm_idx] = static_cast<int>(std::max(
@@ -797,7 +789,7 @@ void _sort_trained(RandomIt begin, RandomIt end, learned_sort::RMI &rmi) {
                                       root_slope * cur_elm + root_intrcpt)));
             // Predict the CDF
             pred_cdf = slopes[model_idx_next_layer] * cur_elm +
-                       intercpts[model_idx_next_layer];
+                       intercepts[model_idx_next_layer];
 
             // Scale the predicted CDF to the input size and cache it
             pred_idx_cache[elm_idx] = static_cast<unsigned int>(std::max(
@@ -953,9 +945,6 @@ void learned_sort::sort(RandomIt begin, RandomIt end, RMI::Params &params) {
       std::max(params.fanout * params.threshold, 5 * params.arch[1])) {
     std::sort(begin, end);
   } else {
-    // Determine the data type
-    typedef typename iterator_traits<RandomIt>::value_type T;
-
     // Train
     RMI rmi = train(begin, end, params);
 

--- a/unit_tests/tests_driver.cc
+++ b/unit_tests/tests_driver.cc
@@ -26,9 +26,9 @@ using namespace std;
 
 /**
  * @brief Global variable dictating the size of the tests (i.e., the number of
- * elements in the random arrays). 20M is the default test size.
+ * elements in the random arrays). Below is the default test size.
  */
-size_t TEST_SIZE = 2e7;
+size_t TEST_SIZE = 12345678;
 
 int main(int argc, char **argv) {
   // Parse command line arguments

--- a/util.h
+++ b/util.h
@@ -80,10 +80,10 @@ long long int get_checksum(vector<T> arr)
 
     vector<T> cpy(arr.begin(), arr.end());
 
-    for (int i = 0; i < arr.size(); i++)
+    for (size_t i = 0; i < arr.size(); i++)
     {
 
-        for (int j = 0; j < sizeof(T); j++)
+        for (size_t j = 0; j < sizeof(T); j++)
         {
             temp = ((short)(((char *)(cpy.data() + i))[j])++ ^
                     (local_checksum >> BYTE_SZ)) &
@@ -110,7 +110,7 @@ vector<T> normal_distr(size_t size, double mean = 0, double stddev = 1)
     normal_distribution<> distribution(mean, stddev);
 
     // Populate the input
-    for (int i = 0; i < size; i++)
+    for (size_t i = 0; i < size; i++)
     {
         arr.push_back(distribution(generator));
     }
@@ -129,7 +129,7 @@ vector<T> uniform_distr(size_t size, double a = 0, double b = 1)
     uniform_real_distribution<> distribution(a, b);
 
     // Populate the input
-    for (int i = 0; i < size; i++)
+    for (size_t i = 0; i < size; i++)
     {
         arr.push_back(distribution(generator));
     }
@@ -148,7 +148,7 @@ vector<T> exponential_distr(size_t size, double lambda = 2, double scale = 1e6)
     exponential_distribution<> distribution(lambda);
 
     // Populate the input
-    for (int i = 0; i < size; i++)
+    for (size_t i = 0; i < size; i++)
     {
         arr.push_back(distribution(generator) * scale);
     }
@@ -167,7 +167,7 @@ vector<T> lognormal_distr(size_t size, double mean = 0, double stddev = 1, doubl
     lognormal_distribution<> distribution(mean, stddev);
 
     // Populate the input
-    for (int i = 0; i < size; i++)
+    for (size_t i = 0; i < size; i++)
     {
         arr.push_back(distribution(generator) * scale);
     }


### PR DESCRIPTION
Resolves #2 

1. Change rmi.training sample to a vector of doubles instead of an array of doubles, since this is safer for pointer arithmetics.
2. Remove the variable rmi.traning_sample_sz since the vector keeps track of the size.
3. Rename intercpts to intercepts in _trained_sort function.
4. Change the default test size from 20M to 12345678 (approx. 12.3M) to ensure that we have tests for arbitrary sizes, and not just multiples of 1000.